### PR TITLE
Update deployment scripts to use the new v2 subgraph

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "scripts": {
     "codegen": "graph codegen",
     "build": "graph build",
-    "deploy": "graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ protofire/makerdao-governance",
-    "create-local": "graph create --node http://localhost:8020/ protofire/makerdao-governance",
-    "remove-local": "graph remove --node http://localhost:8020/ protofire/makerdao-governance",
-    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 protofire/makerdao-governance"
+    "deploy": "graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ protofire/makerdao-governance-v2",
+    "create-local": "graph create --node http://localhost:8020/ protofire/makerdao-governance-v2",
+    "remove-local": "graph remove --node http://localhost:8020/ protofire/makerdao-governance-v2",
+    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 protofire/makerdao-governance-v2"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
This updates the deployment scripts to use the new `v2` subgraph on new releases.